### PR TITLE
Update ValidModel.php

### DIFF
--- a/src/Sudzy/ValidModel.php
+++ b/src/Sudzy/ValidModel.php
@@ -93,7 +93,13 @@ abstract class ValidModel extends \Model
     public function validateProperty($prop, $value, $throw = false)
     {
         $this->lazyLoadValidations();
-
+        
+        // If prop is actaully an Array by using Model->set(Array), return true to prevent warnings from unset()
+        if (is_array($prop))
+        {
+            return true;
+        }
+        
         unset($this->_validationErrors[$prop]);
         unset($this->_validationExceptions[$prop]);
 


### PR DESCRIPTION
PHP throws warnings below when using Model->set([])  - to set the data, somehow the first prop it validates is an array. Have a fix here, but that just prevents the warning from happening, not sure how to fix that underlying issue. 

`Warning: Illegal offset type in unset in /Sudzy/ValidModel.php on line 80`

`Warning: Illegal offset type in unset in /Sudzy/ValidModel.php on line 81`

`Warning: Illegal offset type in isset or empty in Sudzy/ValidModel.php on line 87`